### PR TITLE
add "etc" ruby gem

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
       ruby \
       ruby-bundler \
       ruby-dev \
+      ruby-etc \
       ruby-irb \
       ruby-json \
       tar \


### PR DESCRIPTION
This used to be part of stdlib, but is now standalone in Alpine 3.8.