### PR TITLE
remove hook that does not work in this environment

### DIFF
--- a/src/.pre-commit-config.yaml
+++ b/src/.pre-commit-config.yaml
@@ -58,8 +58,6 @@ repos:
       - id: forbid-new-submodules
       - id: mixed-line-ending
         args: [--fix=lf]
-      - id: no-commit-to-branch
-        args: [--branch, master]
       - id: pretty-format-json
       - id: requirements-txt-fixer
       - id: sort-simple-yaml


### PR DESCRIPTION
The hook fails after merge to master, so it does not work as expected.