### PR TITLE
Install terraform and terragrunt

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.15.3
 ENV GOSS_VERSION 0.3.11
 ENV BATS_VERSION 1.2.0
 ENV SHFMT_VERSION v3.1.1
+ENV TERRAGRUNT_VERSION 0.36.11
 
 RUN apk add --no-cache \
       -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
@@ -45,6 +46,7 @@ RUN apk add --no-cache \
       ruby-irb \
       ruby-json \
       tar \
+      terraform \
       xz \
       yaml-dev \
       && \
@@ -87,6 +89,10 @@ RUN curl -L -ssL -o /usr/local/bin/shfmt "https://github.com/mvdan/sh/releases/d
 # Install https://github.com/rhysd/actionlint
 RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest &&            \
     ln -s /root/go/bin/actionlint /usr/bin/actionlint
+
+# Install terragrunt
+RUN curl -L -ssL -o /usr/local/bin/terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64" && \
+    chmod 0755 /usr/local/bin/terragrunt
 
 # Cache a bunch of pre-commit hook environments
 # to reduce runtimes on circleci

--- a/src/goss.yaml
+++ b/src/goss.yaml
@@ -63,6 +63,12 @@ command:
   command -v go:
     exit-status: 0
 
+  terraform --version:
+    exit-status: 0
+
+  terragrunt --version:
+    exit-status: 0
+
 package:
   docker:
     installed: true


### PR DESCRIPTION
I want to use the following linters which needs terraform and terragrunt:
- repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.71.0
    hooks:
      - id: terraform_fmt
      - id: terraform_validate
      - id: terragrunt_fmt